### PR TITLE
TerminateAllCalls() method available in Linphone.cs

### DIFF
--- a/Linphone.cs
+++ b/Linphone.cs
@@ -867,6 +867,11 @@ namespace sipdotnet
 	
         public void TerminateAllCalls()
         {
+			if (linphoneCore == IntPtr.Zero || !running) {
+				if (ErrorEvent != null)
+					ErrorEvent (null, "Cannot terminate calls when Linphone Core is not working.");
+				return;
+			}
             linphone_core_terminate_all_calls(linphoneCore);
         }
 

--- a/Linphone.cs
+++ b/Linphone.cs
@@ -864,6 +864,11 @@ namespace sipdotnet
 			LinphoneCall linphonecall = (LinphoneCall) call;
 			linphone_core_terminate_call (linphoneCore, linphonecall.LinphoneCallPtr);
         }
+	
+        public void TerminateAllCalls()
+        {
+            linphone_core_terminate_all_calls(linphoneCore);
+        }
 
 		public void MakeCall (string uri)
 		{

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Current available functionality:
      - `ReceiveCall`
      - `ReceiveCallAndRecord`
      - `TerminateCall`
+     - `TerminateAllCalls` (what's different with this fork compared to [original repo](https://github.com/bedefaced/sipdotnet), thanks again bedefaced)
+
  - Utilities:
 	 - `SendDTMFs` (sending DTMF-tones)
 	 - `SetIncomingRingSound` and `SetRingbackSound` (sound that is heard when it's ringing to remote party)


### PR DESCRIPTION
Without this, for calls that were initialized but nobody answered yet (no voice mail, nobody hit busy, etc) it was impossible to terminate a call. 

This adds the ability to terminate all calls. Hope it helps somebody else too !